### PR TITLE
' and " in Nosto tag data removed

### DIFF
--- a/Nosto_Tagging/code/community/Nosto/Tagging/Helper/Data.php
+++ b/Nosto_Tagging/code/community/Nosto/Tagging/Helper/Data.php
@@ -165,4 +165,38 @@ class Nosto_Tagging_Helper_Data extends Mage_Core_Helper_Abstract
     {
         return (boolean)Mage::getStoreConfig(self::XML_PATH_COLLECT_EMAIL_ADDRESSES, $store);
     }
+    
+    /**
+     * Escape html entities and remove ' & "
+     *
+     * @param   mixed $data
+     * @param   array $allowedTags
+     * @return  mixed
+     */
+    public function escapeHtml($data, $allowedTags = null)
+    {
+        if (is_array($data)) {
+            $result = array();
+            foreach ($data as $item) {
+                $result[] = $this->escapeHtml($item);
+            }
+        } else {
+            // process single item
+            if (strlen($data)) {
+                if (is_array($allowedTags) and !empty($allowedTags)) {
+                    $allowed = implode('|', $allowedTags);
+                    $result = preg_replace('/<([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)>/si', '##$1$2$3##', $data);
+                    $result = htmlspecialchars($result, ENT_COMPAT, 'UTF-8', false);
+                    $result = preg_replace('/##([\/\s\r\n]*)(' . $allowed . ')([\/\s\r\n]*)##/si', '<$1$2$3>', $result);
+                } else {
+                    $result = htmlspecialchars($data, ENT_COMPAT, 'UTF-8', false);
+                }
+            } else {
+                $result = $data;
+            }
+            $remove = array("'","\"");
+            $result = str_replace($remove, "", $data);
+        }
+        return $result;
+    }
 }


### PR DESCRIPTION
Apostrophes and quotations in the Nosto tag displayed causing breaks in the information being sent back to Nosto.  Moved a modified escapeHtml function into the Nosto Data Helper which also removes ' and ".