### PR TITLE
Hole punching for Magento Enterprise FPC

### DIFF
--- a/Nosto_Tagging/code/community/Nosto/Tagging/Model/Container/Cart.php
+++ b/Nosto_Tagging/code/community/Nosto/Tagging/Model/Container/Cart.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category    Nosto
+ * @package     Nosto_Tagging
+ * @copyright   Copyright (c) 2013 Nosto Solutions Ltd (http://www.nosto.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Cart Container model.
+ * Used to keep cart tagging block up to date when FPC is used.
+ *
+ * @category    Nosto
+ * @package     Nosto_Tagging
+ * @author      Nosto Solutions Ltd
+ */
+
+class Nosto_Tagging_Model_Container_Cart extends Enterprise_PageCache_Model_Container_Advanced_Quote
+{
+    /**
+    * Get identifier from cookies
+    *
+    * @deprecated since 1.12.0.0
+    * @return string
+    */
+    protected function _getIdentifier()
+    {
+        return $this->_getCookieValue(Enterprise_PageCache_Model_Cookie::COOKIE_CART, '')
+            . $this->_getCookieValue(Enterprise_PageCache_Model_Cookie::COOKIE_CUSTOMER, '');
+    }
+
+    /**
+    * Render block content
+    *
+    * @return string
+    */
+    protected function _renderBlock()
+    {
+        $block = $this->_getPlaceHolderBlock();
+        return $block->toHtml();
+    }
+}

--- a/Nosto_Tagging/code/community/Nosto/Tagging/Model/Container/Customer.php
+++ b/Nosto_Tagging/code/community/Nosto/Tagging/Model/Container/Customer.php
@@ -1,0 +1,73 @@
+
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category    Nosto
+ * @package     Nosto_Tagging
+ * @copyright   Copyright (c) 2013 Nosto Solutions Ltd (http://www.nosto.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Cart Container model.
+ * Used to keep user tagging block up to date when FPC is used.
+ *
+ * @category    Nosto
+ * @package     Nosto_Tagging
+ * @author      Nosto Solutions Ltd
+ */
+
+class Nosto_Tagging_Model_Container_Customer extends Enterprise_PageCache_Model_Container_Customer
+{
+    /**
+    * Get identifier from cookies
+    *
+    * @return string
+    */
+    protected function _getIdentifier()
+    {
+        $cacheId = $this->_getCookieValue(Enterprise_PageCache_Model_Cookie::COOKIE_CUSTOMER, '')
+            . '_'
+            . $this->_getCookieValue(Enterprise_PageCache_Model_Cookie::COOKIE_CUSTOMER_LOGGED_IN, '');
+        return $cacheId;
+    }
+
+	/**
+    * Get cache identifier
+    *
+    * @return string
+    */
+    protected function _getCacheId()
+    {
+        return 'CONTAINER_NOSTO_TAGGING_CUSTOMER_' . md5($this->_placeholder->getAttribute('cache_id') . $this->_getIdentifier());
+    }
+
+    /**
+    * Render block content
+    *
+    * @return string
+    */
+    protected function _renderBlock()
+    {
+        $block = $this->_getPlaceHolderBlock();
+        Mage::dispatchEvent('render_block', array('block' => $block, 'placeholder' => $this->_placeholder));
+        return $block->toHtml();
+    }
+}

--- a/Nosto_Tagging/code/community/Nosto/Tagging/etc/cache.xml
+++ b/Nosto_Tagging/code/community/Nosto/Tagging/etc/cache.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category    Nosto
+ * @package     Nosto_Tagging
+ * @copyright   Copyright (c) 2013 Nosto Solutions Ltd (http://www.nosto.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+-->
+<config>
+    <placeholders>
+        <nosto_tagging_cart>
+            <block>nosto_tagging/cart</block>
+            <name>nosto.cart</name>
+            <placeholder>NOSTO_TAGGING_CART_CACHE</placeholder>
+            <container>Nosto_Tagging_Model_Container_Cart</container>
+            <cache_life>86400</cache_life>
+        </nosto_tagging_cart>
+        <nosto_tagging_customer>
+            <block>nosto_tagging/customer</block>
+            <name>nosto.customer</name>
+            <placeholder>NOSTO_TAGGING_CUSTOMER_CACHE</placeholder>
+            <container>Nosto_Tagging_Model_Container_Customer</container>
+            <cache_life>86400</cache_life>
+        </nosto_tagging_customer>
+    </placeholders>
+</config>


### PR DESCRIPTION
When using Magento Enterprise's full page caching, most of the tagging elements are being cached. While this is not a problem for most tagging elements, the cart and customer tagging can get cached and therefore be transfered between customers. We saw the results of this when one of our clients got word from his customers that they were sent other people's carts in the "abandoned cart" emails.

This fix punches holes in the cache, so that the Nosto customer and cart tagging elements will always be up to date, and not cached between sessions.